### PR TITLE
MQTT - segmentation fault on init mqtt conncetion with an old mosquitto version

### DIFF
--- a/lib/AgrirouterClient/inc/MqttConnectionClient.h
+++ b/lib/AgrirouterClient/inc/MqttConnectionClient.h
@@ -5,6 +5,8 @@
 #include "Settings.h"
 #include "third_party/mosquitto/mosquitto.h"
 
+#include <mutex>
+
 class MqttConnectionClient {
 
 public:
@@ -29,6 +31,9 @@ public:
     void setMember(void* member);
     void* getMember();
 
+    static std::string getStaticSecret();
+    static void setStaticSecret(std::string secret);
+
     bool isConnected();
 
 private:
@@ -44,6 +49,9 @@ private:
 
     MqttCallback m_mqttCallback;
     MqttErrorCallback m_mqttErrorCallback;
+
+    static std::string globalSecret;
+    static std::mutex mutexSecret;
 
     static int onPWCallback(char *buf, int size, int rwflag, void *userdata);
     static void connectCallback(struct mosquitto *mosq, void *obj, int result);

--- a/lib/AgrirouterClient/inc/MqttConnectionClient.h
+++ b/lib/AgrirouterClient/inc/MqttConnectionClient.h
@@ -31,9 +31,6 @@ public:
     void setMember(void* member);
     void* getMember();
 
-    static std::string getStaticSecret();
-    static void setStaticSecret(std::string secret);
-
     bool isConnected();
 
 private:
@@ -50,9 +47,6 @@ private:
     MqttCallback m_mqttCallback;
     MqttErrorCallback m_mqttErrorCallback;
 
-    static std::string globalSecret;
-    static std::mutex mutexSecret;
-
     static int onPWCallback(char *buf, int size, int rwflag, void *userdata);
     static void connectCallback(struct mosquitto *mosq, void *obj, int result);
     static void disconnectCallback(struct mosquitto *mosq, void *obj, int result);
@@ -61,6 +55,11 @@ private:
     static void subscribeCallback(struct mosquitto *mosq, void *obj, int messageId, int qosCount, const int *grantedQos);
     static void unsubscribeCallback(struct mosquitto *mosq, void *obj, int messageId);
     static void messageCallback(struct mosquitto *mosq, void *obj, const struct mosquitto_message *message);
+
+    static std::string globalSecret;
+    static std::mutex mutexSecret;
+    static std::string getStaticSecret();
+    static void setStaticSecret(std::string secret);
 };
 
 #endif // LIB_AGRIROUTERCLIENT_INC_MQTTCONNECTIONCLIENT_H_

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -88,19 +88,6 @@ int MqttConnectionClient::init()
             keepAliveTime = DEFAULT_KEEP_ALIVE_TIME;
         }
 
-        int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
-        if(connect == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: connect set successful - " + std::to_string(connect) + ": " + mosquitto_strerror(connect));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
-            return EXIT_FAILURE;
-        }
-
         int loop = mosquitto_loop_start(m_mosq);
         if(loop == MOSQ_ERR_SUCCESS)
         {
@@ -111,6 +98,19 @@ int MqttConnectionClient::init()
             std::string errorMessage = "MqttConnectionClient: loop start failed " + std::to_string(loop) + ": " + mosquitto_strerror(loop);
             m_settings->callOnLog(MG_LFL_ERR, errorMessage);
             (m_mqttErrorCallback) (loop, errorMessage, "", m_member);
+            return EXIT_FAILURE;
+        }
+
+        int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
+        if(connect == MOSQ_ERR_SUCCESS)
+        {
+            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: connect set successful - " + std::to_string(connect) + ": " + mosquitto_strerror(connect));
+        }
+        else
+        {
+            std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
+            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+            (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
             return EXIT_FAILURE;
         }
 

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -88,19 +88,6 @@ int MqttConnectionClient::init()
             keepAliveTime = DEFAULT_KEEP_ALIVE_TIME;
         }
 
-        int loop = mosquitto_loop_start(m_mosq);
-        if(loop == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: loop set successful - " + std::to_string(loop) + ": " + mosquitto_strerror(loop));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: loop start failed " + std::to_string(loop) + ": " + mosquitto_strerror(loop);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (loop, errorMessage, "", m_member);
-            return EXIT_FAILURE;
-        }
-
         int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
         if(connect == MOSQ_ERR_SUCCESS)
         {
@@ -111,6 +98,19 @@ int MqttConnectionClient::init()
             std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
             m_settings->callOnLog(MG_LFL_ERR, errorMessage);
             (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
+            return EXIT_FAILURE;
+        }
+
+        int loop = mosquitto_loop_start(m_mosq);
+        if(loop == MOSQ_ERR_SUCCESS)
+        {
+            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: loop set successful - " + std::to_string(loop) + ": " + mosquitto_strerror(loop));
+        }
+        else
+        {
+            std::string errorMessage = "MqttConnectionClient: loop start failed " + std::to_string(loop) + ": " + mosquitto_strerror(loop);
+            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+            (m_mqttErrorCallback) (loop, errorMessage, "", m_member);
             return EXIT_FAILURE;
         }
 


### PR DESCRIPTION
When the agrirouterclient try to connect with mqtt with an old mosquitto version (older then v1.6.15) the callback onPWCallback had no userdata.
