### PR TITLE
MQTT - fix crash on reconnect and incoming message

### DIFF
--- a/lib/AgrirouterClient/inc/AgrirouterClient.h
+++ b/lib/AgrirouterClient/inc/AgrirouterClient.h
@@ -17,6 +17,8 @@ class AgrirouterClient {
         explicit AgrirouterClient(Settings *settings, uint32_t chunkSize);
         ~AgrirouterClient();
 
+        void renewConnection();
+
         void registerDeviceWithRegCode(const std::string& registrationCode, AgrirouterSettings& agrirouterSettings);
 
         // Messages without specific recipients
@@ -36,7 +38,7 @@ class AgrirouterClient {
         void sendTaskdataZip(Addressing& addressing, std::string *messageId, const std::string& teamsetId, char *taskdataZip, int size, const std::string& fileName = "");
         void sendChunk(AgrirouterMessage& message);
 
-        AgrirouterMessage createChunkMessage(std::string *messageId, Addressing& addressing, uint16_t numberOfChunk, uint16_t numberOfChunks, 
+        AgrirouterMessage createChunkMessage(std::string *messageId, Addressing& addressing, uint16_t numberOfChunk, uint16_t numberOfChunks,
                                                 const std::string& teamSetContextId, const std::string& chunkContextId, const std::string& data,
                                                 uint32_t size, const std::string& technicalMessageType, const std::string& fileName = "");
 

--- a/lib/AgrirouterClient/inc/ConnectionProvider.h
+++ b/lib/AgrirouterClient/inc/ConnectionProvider.h
@@ -19,6 +19,8 @@ class ConnectionProvider
 
         virtual ~ConnectionProvider() {}
 
+        virtual void renewConnection() {}
+
         // Function pointer for callback functions
         typedef size_t (*Callback)(char *content, size_t size, size_t nmemb, void *member);
 

--- a/lib/AgrirouterClient/inc/Definitions.h
+++ b/lib/AgrirouterClient/inc/Definitions.h
@@ -84,13 +84,13 @@
 #define MESSAGE_TYPE_DEVICE_DESCRIPTION "iso:11783:-10:device_description:protobuf"
 
 // loglevel
-#define MG_LFL_CRI 1  // critical  
-#define MG_LFL_ERR 2  // error  
-#define MG_LFL_WRN 3  // warning  
-#define MG_LFL_MSG 4  // message  
-#define MG_LFL_NTC 5  // notice  
-#define MG_LFL_TRC 6  // trace  
-#define MG_LFL_DBG 7  // debug  
+#define MG_LFL_CRI 1  // critical
+#define MG_LFL_ERR 2  // error
+#define MG_LFL_WRN 3  // warning
+#define MG_LFL_MSG 4  // message
+#define MG_LFL_NTC 5  // notice
+#define MG_LFL_TRC 6  // trace
+#define MG_LFL_DBG 7  // debug
 
 // Other definitions
 #define DEFAULT_CHUNK_SIZE 300000 // 0,3 MB

--- a/lib/AgrirouterClient/inc/MqttConnectionClient.h
+++ b/lib/AgrirouterClient/inc/MqttConnectionClient.h
@@ -44,8 +44,8 @@ private:
     void *m_member = nullptr;
     Settings *m_settings = nullptr;
 
-    MqttCallback m_mqttCallback;
-    MqttErrorCallback m_mqttErrorCallback;
+    MqttCallback m_mqttCallback = NULL;
+    MqttErrorCallback m_mqttErrorCallback = NULL;
 
     static int onPWCallback(char *buf, int size, int rwflag, void *userdata);
     static void connectCallback(struct mosquitto *mosq, void *obj, int result);

--- a/lib/AgrirouterClient/inc/MqttConnectionProvider.h
+++ b/lib/AgrirouterClient/inc/MqttConnectionProvider.h
@@ -14,8 +14,10 @@ class MqttConnectionProvider : public ConnectionProvider
         explicit MqttConnectionProvider(Settings *settings);
         ~MqttConnectionProvider();
 
+        void renewConnection() override;
+
         // Struct to use curl chunked callbacks
-        typedef struct MemoryStruct 
+        typedef struct MemoryStruct
         {
             char *memory = nullptr;
             size_t size = 0;

--- a/lib/AgrirouterClient/inc/Settings.h
+++ b/lib/AgrirouterClient/inc/Settings.h
@@ -17,7 +17,7 @@ class Settings
 
         typedef void (*onParameterChangeCallback) (int event, void *data, void *callbackCallee);
         typedef void (*onMessageCallback) (int event, Response *response, std::string applicationMessageId, void *callbackCallee);
-        typedef void (*onErrorCallback) (int statusCode, int connectionProviderErrorCode, std::string errorMessage, 
+        typedef void (*onErrorCallback) (int statusCode, int connectionProviderErrorCode, std::string errorMessage,
                                             std::string applicationMessageId, std::string errorContent, void *callbackCallee);
         typedef void (*onLoggingCallback) (int logLevel, std::string logMessage, void *callbackCallee);
 

--- a/lib/AgrirouterClient/src/AgrirouterClient.cpp
+++ b/lib/AgrirouterClient/src/AgrirouterClient.cpp
@@ -41,7 +41,6 @@ void AgrirouterClient::init(Settings *settings)
         m_messageProvider = nullptr;
     }
     m_messageProvider = new MessageProvider(settings, m_chunkSize);
-
     if(m_connectionProvider != nullptr)
     {
         delete m_connectionProvider;
@@ -49,7 +48,7 @@ void AgrirouterClient::init(Settings *settings)
     }
 
     if (settings->getConnectionType() == Settings::HTTP)
-    {        
+    {
         m_connectionProvider = new CurlConnectionProvider(settings);
     }
     else if (settings->getConnectionType() == Settings::MQTT)
@@ -83,14 +82,9 @@ void AgrirouterClient::registerDeviceWithRegCode(const std::string& registration
 void AgrirouterClient::registrationCallback(bool success, void *member)
 {
     AgrirouterClient *self = static_cast<AgrirouterClient*>(member);
-    if(success) 
+    if(success)
     {
         // reinit connection provider after onboard to new subscribe to the new topics
-        if (self->m_connectionProvider != nullptr)
-        {
-            delete self->m_connectionProvider;
-            self->m_connectionProvider = nullptr;
-        }
         self->init(self->m_settings);
     }
     else
@@ -112,6 +106,14 @@ int32_t AgrirouterClient::getNextSeqNo()
     }
 
     return m_seqNo;
+}
+
+void AgrirouterClient::renewConnection()
+{
+    if (m_settings->getConnectionType() == Settings::MQTT)
+    {
+        m_connectionProvider->renewConnection();
+    }
 }
 
 void AgrirouterClient::sendCapabilities(std::string *messageId, CapabilitySpecification *capabilities)
@@ -220,10 +222,9 @@ void AgrirouterClient::requestMessages()
 
 size_t AgrirouterClient::requestMessagesCallback(char *content, size_t size, size_t nmemb, void *member)
 {
-    size_t realsize = size * nmemb;
-
     AgrirouterClient *self = static_cast<AgrirouterClient *>(member);
 
+    size_t realsize = size * nmemb;
     std::string message(content, realsize);
 
     std::list<Response> responseList;

--- a/lib/AgrirouterClient/src/AgrirouterClient.cpp
+++ b/lib/AgrirouterClient/src/AgrirouterClient.cpp
@@ -54,6 +54,7 @@ void AgrirouterClient::init(Settings *settings)
     else if (settings->getConnectionType() == Settings::MQTT)
     {
         m_connectionProvider = new MqttConnectionProvider(settings);
+        m_connectionProvider->renewConnection();
     }
 }
 

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -188,7 +188,6 @@ void MqttConnectionClient::disconnectCallback(struct mosquitto *mosq, void *obj,
         self->m_settings->callOnLog(MG_LFL_ERR, errorMessage);
         (self->m_mqttErrorCallback) (reasonCode, errorMessage, "", self->m_member);
 
-
         // try to reconnect
         int reconn = mosquitto_reconnect(self->m_mosq);
         if (reconn == MOSQ_ERR_SUCCESS)

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -19,6 +19,7 @@ MqttConnectionClient::~MqttConnectionClient()
     if(m_mosq != nullptr)
     {
         mosquitto_disconnect(m_mosq);
+        mosquitto_loop_stop(m_mosq, true);
         mosquitto_destroy(m_mosq);
     }
     mosquitto_lib_cleanup();
@@ -121,7 +122,7 @@ int MqttConnectionClient::init()
     }
     else
     {
-        m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient not connect to broker");
+        m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: not connect to broker");
     }
     return EXIT_FAILURE;
 }
@@ -165,7 +166,7 @@ void MqttConnectionClient::connectCallback(struct mosquitto *mosq, void *obj, in
     self->m_connected = true;
     if(reasonCode == 0)
     {
-        self->m_settings->callOnLog(MG_LFL_MSG, "MqttConnectionClient: Connected to MQTT Broker (" + self->m_host + ":" + std::to_string(self->m_port));
+        self->m_settings->callOnLog(MG_LFL_MSG, "MqttConnectionClient: Connected to MQTT Broker (" + self->m_host + ":" + std::to_string(self->m_port) + ")");
     }
     else
     {

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -113,11 +113,12 @@ int MqttConnectionClient::init()
             std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
             m_settings->callOnLog(MG_LFL_ERR, errorMessage);
             (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
-            return EXIT_FAILURE;
+            // not return fail, the mosquitto_loop trigger the connect until it is connected
         }
 
-        if ((connect == MOSQ_ERR_SUCCESS) && (loop == MOSQ_ERR_SUCCESS))
+        if (loop == MOSQ_ERR_SUCCESS)
         {
+            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: init success");
             return EXIT_SUCCESS;
         }
     }

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -30,102 +30,103 @@ int MqttConnectionClient::init()
     mosquitto_lib_init();
     m_mosq = mosquitto_new(m_clientId.c_str(), false, (void *) this);
 
-    if (m_mosq != nullptr)
+    if (m_mosq == nullptr)
     {
-        mosquitto_connect_callback_set(m_mosq, connectCallback);
-        mosquitto_disconnect_callback_set(m_mosq, disconnectCallback);
-        mosquitto_publish_callback_set(m_mosq, publishCallback);
-        mosquitto_log_callback_set(m_mosq, loggingCallback);
-        mosquitto_subscribe_callback_set(m_mosq, subscribeCallback);
-        mosquitto_unsubscribe_callback_set(m_mosq, unsubscribeCallback);
-        mosquitto_message_callback_set(m_mosq, messageCallback);
-        mosquitto_reconnect_delay_set(m_mosq, 2, 120, true);
+        m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: not connect to broker");
+        return EXIT_FAILURE;
+    }
 
-        int tlsInsecure = mosquitto_tls_insecure_set(m_mosq, false);
-        if(tlsInsecure == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: tlsInsecure set successful - " + std::to_string(tlsInsecure) + ": " + mosquitto_strerror(tlsInsecure));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: tlsInsecure set failed " + std::to_string(tlsInsecure) + ": " + mosquitto_strerror(tlsInsecure);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (tlsInsecure, errorMessage, "", m_member);
-            return EXIT_FAILURE;
-        }
+    mosquitto_connect_callback_set(m_mosq, connectCallback);
+    mosquitto_disconnect_callback_set(m_mosq, disconnectCallback);
+    mosquitto_publish_callback_set(m_mosq, publishCallback);
+    mosquitto_log_callback_set(m_mosq, loggingCallback);
+    mosquitto_subscribe_callback_set(m_mosq, subscribeCallback);
+    mosquitto_unsubscribe_callback_set(m_mosq, unsubscribeCallback);
+    mosquitto_message_callback_set(m_mosq, messageCallback);
+    mosquitto_reconnect_delay_set(m_mosq, 2, 120, true);
 
-        int tlsOptsSet = mosquitto_tls_opts_set(m_mosq, 1, NULL, NULL);
-        if(tlsOptsSet == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: tlsOptsSet set successful - " + std::to_string(tlsOptsSet) + ": " + mosquitto_strerror(tlsOptsSet));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: tlsOptsSet set failed " + std::to_string(tlsOptsSet) + ": " + mosquitto_strerror(tlsOptsSet);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (tlsOptsSet, errorMessage, "", m_member);
-            return EXIT_FAILURE;
-        }
-
-        std::string caCerts = m_settings->getCertificateCaPath();
-        std::string client_certificate = m_settings->getCertificatePath();
-        std::string client_key = m_settings->getPrivateKeyPath();
-
-        int tlsSet = mosquitto_tls_set(m_mosq, nullptr, caCerts.c_str(), client_certificate.c_str(), client_key.c_str(), onPWCallback);
-        if(tlsSet == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: tlsSet set successful - " + std::to_string(tlsSet) + ": " + mosquitto_strerror(tlsSet));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: tlsSet set failed " + std::to_string(tlsSet) + ": " + mosquitto_strerror(tlsSet);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            std::string errorJSON = "{\"error\":{\"code\":\""+ std::to_string(MG_ERROR_MISSING_OR_EXPIRED_CERTIFICATE) + "\",\"message\":\"" + errorMessage + "\",\"target\":\"agrirouter-api-cpp\",\"details\":[]}}";
-            (m_mqttErrorCallback) (MG_ERROR_MISSING_OR_EXPIRED_CERTIFICATE, "MqttConnectionClient: MQTT TLS Failed", errorJSON, m_member);
-            return EXIT_FAILURE;
-        }
-        int keepAliveTime = m_settings->getMqttKeepAliveTime();
-        if(keepAliveTime == 0)
-        {
-            keepAliveTime = DEFAULT_KEEP_ALIVE_TIME;
-        }
-
-        int loop = mosquitto_loop_start(m_mosq);
-        if(loop == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: loop set successful - " + std::to_string(loop) + ": " + mosquitto_strerror(loop));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: loop start failed " + std::to_string(loop) + ": " + mosquitto_strerror(loop);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (loop, errorMessage, "", m_member);
-            return EXIT_FAILURE;
-        }
-
-        int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
-        if(connect == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: connect set successful - " + std::to_string(connect) + ": " + mosquitto_strerror(connect));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
-            // not return fail, the mosquitto_loop trigger the connect until it is connected
-        }
-
-        if (loop == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: init success");
-            return EXIT_SUCCESS;
-        }
+    int tlsInsecure = mosquitto_tls_insecure_set(m_mosq, false);
+    if(tlsInsecure == MOSQ_ERR_SUCCESS)
+    {
+        m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: tlsInsecure set successful - " + std::to_string(tlsInsecure) + ": " + mosquitto_strerror(tlsInsecure));
     }
     else
     {
-        m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: not connect to broker");
+        std::string errorMessage = "MqttConnectionClient: tlsInsecure set failed " + std::to_string(tlsInsecure) + ": " + mosquitto_strerror(tlsInsecure);
+        m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+        (m_mqttErrorCallback) (tlsInsecure, errorMessage, "", m_member);
+        return EXIT_FAILURE;
     }
+
+    int tlsOptsSet = mosquitto_tls_opts_set(m_mosq, 1, NULL, NULL);
+    if(tlsOptsSet == MOSQ_ERR_SUCCESS)
+    {
+        m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: tlsOptsSet set successful - " + std::to_string(tlsOptsSet) + ": " + mosquitto_strerror(tlsOptsSet));
+    }
+    else
+    {
+        std::string errorMessage = "MqttConnectionClient: tlsOptsSet set failed " + std::to_string(tlsOptsSet) + ": " + mosquitto_strerror(tlsOptsSet);
+        m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+        (m_mqttErrorCallback) (tlsOptsSet, errorMessage, "", m_member);
+        return EXIT_FAILURE;
+    }
+
+    std::string caCerts = m_settings->getCertificateCaPath();
+    std::string client_certificate = m_settings->getCertificatePath();
+    std::string client_key = m_settings->getPrivateKeyPath();
+
+    int tlsSet = mosquitto_tls_set(m_mosq, nullptr, caCerts.c_str(), client_certificate.c_str(), client_key.c_str(), onPWCallback);
+    if(tlsSet == MOSQ_ERR_SUCCESS)
+    {
+        m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: tlsSet set successful - " + std::to_string(tlsSet) + ": " + mosquitto_strerror(tlsSet));
+    }
+    else
+    {
+        std::string errorMessage = "MqttConnectionClient: tlsSet set failed " + std::to_string(tlsSet) + ": " + mosquitto_strerror(tlsSet);
+        m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+        std::string errorJSON = "{\"error\":{\"code\":\""+ std::to_string(MG_ERROR_MISSING_OR_EXPIRED_CERTIFICATE) + "\",\"message\":\"" + errorMessage + "\",\"target\":\"agrirouter-api-cpp\",\"details\":[]}}";
+        (m_mqttErrorCallback) (MG_ERROR_MISSING_OR_EXPIRED_CERTIFICATE, "MqttConnectionClient: MQTT TLS Failed", errorJSON, m_member);
+        return EXIT_FAILURE;
+    }
+
+    int keepAliveTime = m_settings->getMqttKeepAliveTime();
+    if(keepAliveTime == 0)
+    {
+        keepAliveTime = DEFAULT_KEEP_ALIVE_TIME;
+    }
+
+    int loop = mosquitto_loop_start(m_mosq);
+    if(loop == MOSQ_ERR_SUCCESS)
+    {
+        m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: loop set successful - " + std::to_string(loop) + ": " + mosquitto_strerror(loop));
+    }
+    else
+    {
+        std::string errorMessage = "MqttConnectionClient: loop start failed " + std::to_string(loop) + ": " + mosquitto_strerror(loop);
+        m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+        (m_mqttErrorCallback) (loop, errorMessage, "", m_member);
+        return EXIT_FAILURE;
+    }
+
+    int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
+    if(connect == MOSQ_ERR_SUCCESS)
+    {
+        m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: connect set successful - " + std::to_string(connect) + ": " + mosquitto_strerror(connect));
+    }
+    else
+    {
+        std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
+        m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+        (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
+        // not return fail, the mosquitto_loop trigger the connect until it is connected
+    }
+
+    if (loop == MOSQ_ERR_SUCCESS)
+    {
+        m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: init success");
+        return EXIT_SUCCESS;
+    }
+
     return EXIT_FAILURE;
 }
 

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionClient.cpp
@@ -39,6 +39,7 @@ int MqttConnectionClient::init()
         mosquitto_subscribe_callback_set(m_mosq, subscribeCallback);
         mosquitto_unsubscribe_callback_set(m_mosq, unsubscribeCallback);
         mosquitto_message_callback_set(m_mosq, messageCallback);
+        mosquitto_reconnect_delay_set(m_mosq, 2, 120, true);
 
         int tlsInsecure = mosquitto_tls_insecure_set(m_mosq, false);
         if(tlsInsecure == MOSQ_ERR_SUCCESS)
@@ -89,19 +90,6 @@ int MqttConnectionClient::init()
             keepAliveTime = DEFAULT_KEEP_ALIVE_TIME;
         }
 
-        int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
-        if(connect == MOSQ_ERR_SUCCESS)
-        {
-            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: connect set successful - " + std::to_string(connect) + ": " + mosquitto_strerror(connect));
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
-            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
-            return EXIT_FAILURE;
-        }
-
         int loop = mosquitto_loop_start(m_mosq);
         if(loop == MOSQ_ERR_SUCCESS)
         {
@@ -112,6 +100,19 @@ int MqttConnectionClient::init()
             std::string errorMessage = "MqttConnectionClient: loop start failed " + std::to_string(loop) + ": " + mosquitto_strerror(loop);
             m_settings->callOnLog(MG_LFL_ERR, errorMessage);
             (m_mqttErrorCallback) (loop, errorMessage, "", m_member);
+            return EXIT_FAILURE;
+        }
+
+        int connect = mosquitto_connect_async(m_mosq, m_host.c_str(), m_port, keepAliveTime);
+        if(connect == MOSQ_ERR_SUCCESS)
+        {
+            m_settings->callOnLog(MG_LFL_NTC, "MqttConnectionClient: connect set successful - " + std::to_string(connect) + ": " + mosquitto_strerror(connect));
+        }
+        else
+        {
+            std::string errorMessage = "MqttConnectionClient: connect set failed " + std::to_string(connect) + ": " + mosquitto_strerror(connect);
+            m_settings->callOnLog(MG_LFL_ERR, errorMessage);
+            (m_mqttErrorCallback) (connect, errorMessage, "", m_member);
             return EXIT_FAILURE;
         }
 
@@ -188,19 +189,6 @@ void MqttConnectionClient::disconnectCallback(struct mosquitto *mosq, void *obj,
         std::string errorMessage = "MqttConnectionClient: disconnect unexpected " + std::to_string(reasonCode) + ": " + mosquitto_connack_string(reasonCode);
         self->m_settings->callOnLog(MG_LFL_ERR, errorMessage);
         (self->m_mqttErrorCallback) (reasonCode, errorMessage, "", self->m_member);
-
-        // try to reconnect
-        int reconn = mosquitto_reconnect(self->m_mosq);
-        if (reconn == MOSQ_ERR_SUCCESS)
-        {
-            self->m_settings->callOnLog(MG_LFL_MSG, "MqttConnectionClient: Reconnected");
-        }
-        else
-        {
-            std::string errorMessage = "MqttConnectionClient: reconnect failed " + std::to_string(reconn) + ": " + mosquitto_strerror(reconn);
-            self->m_settings->callOnLog(MG_LFL_ERR, errorMessage);
-            (self->m_mqttErrorCallback) (reconn, errorMessage, "", self->m_member);
-        }
     }
 }
 

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
@@ -46,6 +46,11 @@ void MqttConnectionProvider::init()
     }
 }
 
+void MqttConnectionProvider::renewConnection()
+{
+    this->init();
+}
+
 void MqttConnectionProvider::requestMqttErrorCallback(int errorCode, std::string message, std::string content, void *member)
 {
     MqttConnectionProvider *self = static_cast<MqttConnectionProvider *>(member);
@@ -61,7 +66,7 @@ void MqttConnectionProvider::requestMqttCallback(char *topic, void *payload, int
 {
     MqttConnectionProvider *self = static_cast<MqttConnectionProvider *>(member);
     char* msg = (char*) payload;
-       
+
     if(msg)
     {
         // If msg starts with '{', it is not an array as it comes from curl, so add the square brackets

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
@@ -37,7 +37,36 @@ void MqttConnectionProvider::init()
     m_mqttClient->setMqttCallback(requestMqttCallback);
     m_mqttClient->setMqttErrorCallback(requestMqttErrorCallback);
 
-    m_mqttClient->init();
+    int initRetrunValue = EXIT_FAILURE;
+    const int timeRetry = 1;
+    int retryReconnectCounter = 30 * timeRetry;
+    int counter = 0;
+
+    while (initRetrunValue == EXIT_FAILURE)
+    {
+        if(counter == retryReconnectCounter || counter == 0)
+        {
+            initRetrunValue = m_mqttClient->init();
+            if(initRetrunValue == EXIT_FAILURE)
+            {
+                this->m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: Init failed retry in " + std::to_string(retryReconnectCounter) + "s");
+            }
+        }
+
+        counter++;
+
+        timeval timeout;
+        timeout.tv_sec = timeRetry;
+        timeout.tv_usec = 0;
+
+        int ret = select(0, nullptr, nullptr, nullptr, &timeout);
+
+        if (ret == -1 && errno == EINTR) {
+            // stop on exit application
+            break;
+        }
+    }
+
 
     // subscribe to commands only subscribe when topic is valid (onboarding is done)
     if(conn.commandsUrl.length() > 0)

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
@@ -11,7 +11,6 @@
 MqttConnectionProvider::MqttConnectionProvider(Settings *settings)
 {
     m_settings = settings;
-    this->init();
 }
 
 MqttConnectionProvider::~MqttConnectionProvider()
@@ -38,19 +37,23 @@ void MqttConnectionProvider::init()
     m_mqttClient->setMqttErrorCallback(requestMqttErrorCallback);
 
     int initReturnValue = EXIT_FAILURE;
-    const int timeRetry = 1;
-    int retryReconnectCounter = 30 * timeRetry;
+    const int timeRetry = 1; // time in s to run loop and after it can be stop the app
+    int retryReconnectCounter = 30 * timeRetry; // time in s to retry the mqtt init process
     int counter = 0;
 
     while (initReturnValue == EXIT_FAILURE)
     {
-        if(counter == retryReconnectCounter || counter == 0)
+        if ((counter % retryReconnectCounter) == 0) // Call init() every 30s until it does not fail
         {
             initReturnValue = m_mqttClient->init();
             if(initReturnValue == EXIT_FAILURE)
             {
                 this->m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: Init failed retry in " + std::to_string(retryReconnectCounter) + "s");
             }
+        }
+        else if (initReturnValue == EXIT_SUCCESS)
+        {
+            break;
         }
 
         counter++;
@@ -66,7 +69,6 @@ void MqttConnectionProvider::init()
             break;
         }
     }
-
 
     // subscribe to commands only subscribe when topic is valid (onboarding is done)
     if(conn.commandsUrl.length() > 0)

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
@@ -37,17 +37,17 @@ void MqttConnectionProvider::init()
     m_mqttClient->setMqttCallback(requestMqttCallback);
     m_mqttClient->setMqttErrorCallback(requestMqttErrorCallback);
 
-    int initRetrunValue = EXIT_FAILURE;
+    int initReturnValue = EXIT_FAILURE;
     const int timeRetry = 1;
     int retryReconnectCounter = 30 * timeRetry;
     int counter = 0;
 
-    while (initRetrunValue == EXIT_FAILURE)
+    while (initReturnValue == EXIT_FAILURE)
     {
         if(counter == retryReconnectCounter || counter == 0)
         {
-            initRetrunValue = m_mqttClient->init();
-            if(initRetrunValue == EXIT_FAILURE)
+            initReturnValue = m_mqttClient->init();
+            if(initReturnValue == EXIT_FAILURE)
             {
                 this->m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: Init failed retry in " + std::to_string(retryReconnectCounter) + "s");
             }

--- a/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
+++ b/lib/AgrirouterClient/src/ConnectionProvider/MqttConnectionProvider.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <limits>
 
 MqttConnectionProvider::MqttConnectionProvider(Settings *settings)
 {
@@ -50,13 +51,20 @@ void MqttConnectionProvider::init()
             {
                 this->m_settings->callOnLog(MG_LFL_ERR, "MqttConnectionClient: Init failed retry in " + std::to_string(retryReconnectCounter) + "s");
             }
-        }
-        else if (initReturnValue == EXIT_SUCCESS)
-        {
-            break;
+            else if (initReturnValue == EXIT_SUCCESS)
+            {
+                break;
+            }
         }
 
-        counter++;
+        if (counter < INT32_MAX)
+        {
+            counter++;
+        }
+        else
+        {
+            counter = 0;
+        }
 
         timeval timeout;
         timeout.tv_sec = timeRetry;


### PR DESCRIPTION
If the agrirouterclient sends a message via the agrirouter-api-cpp library and then loses and re-establishes the connection, the mqttconnectionprovider was restarted, but then the callback and the message parameters are missing in the acknowledgment.